### PR TITLE
Fix broken link to pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ You can also check the ***Atomes*** tutorials:
 [jekyll]:https://jekyllrb.com/
 [atomes]:https://atomes.ipcms.fr/
 [ccl]:http://creativecommons.org/licenses/by/3.0/deed.en_US
-[atomes-doc]:/Atomes-doc/atomes-manual.pdf
+[atomes-doc]:atomes-manual.pdf
 [atomes-tuto]:/Atomes-tuto


### PR DESCRIPTION
Maybe you'd want the link to point directly to the pdf file, which would be https://raw.githubusercontent.com/Slookeur/Atomes-doc/main/atomes-manual.pdf

(nothing to do with this commit, on the Atomes site, in Downloads -> Sources, there's a small typo, "G**ti**hub" instead of "Github")